### PR TITLE
Fixed Clans Deleting When Using /clanadmin reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,19 @@ ClansLite comes with `8` permissions:
 * `clanslite.bypass.pvp`
 
 `clanslite.*` is a permission to allow access to ALL functions regardless of operator status.
+
 `clanslite.clan` is by default given to everyone so they can all create, edit and manage a clan.  
+
 `clanslite.admin` is by default given to server operators.
+
 `clanslite.update` is the permission node to allow a player to see in game notifications if there is a plugin update available.
+
 `clanslite.bypass` is the permission node to allow a player to bypass all protections and cooldowns.
+
 `clanslite.bypass.*` is the permission node to allow a player to bypass all protections and cooldowns.
+
 `clanslite.bypass.homecooldown` is the permission node to allow a player to bypass the home command cooldown.
+
 `clanslite.bypass.pvp` is the permission node to allow a player to bypass the friendly fire protections.
 
 ## Config

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ The max clan allies (by default is 4), can be managed in the `plugins/ClansLite/
 ClansLite exposes a variable of `{CLAN}` to use in Essentials Chat or similar.
 
 ## PlaceholderAPI
-ClansLite exposes `4` external placeholders using `PlaceholderAPI` to enable the fetching of a players clan name or the clan prefix.
-The two available placeholders are:
+ClansLite exposes `4` external placeholders using `PlaceholderAPI` to enable the fetching of a players clan name or the clan prefix or if the clan has friendly fire enabled or if the clan has a home set.
+The four available placeholders are:
 * `%clansLite_clanName%`
 * `%clansLite_clanPrefix%`
 * `%clansLite_friendlyFire%`

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ClansLite does not support any grief prevention tools such as land claiming or s
 ClansLite DOES however offer the ability to disable friendly fire within your clan!
 
 ## /clan command
-Aliases: `/clans`, `/c`  
+Aliases: `/clans`, `/c`, `cl`  
   
 The `/clan` command is the main command of the plugin, with `/clan` you can do the following:
 * `/clan create <name>` - Creates A new clan if not already in one
@@ -21,7 +21,7 @@ The `/clan` command is the main command of the plugin, with `/clan` you can do t
 * `/clan [sethome|home]` - Will set a clan home location or teleport you or you clan members to this location.
 
 ## /clanadmin command
-Aliases: `/ca`  
+Aliases: `/ca`, `cla`
 
 The `/clanadmin` command is purely for server admins only. 
 
@@ -30,16 +30,24 @@ The `/clanadmin` command is purely for server admins only.
 * `/clanadmin reload` - This reloads the plugins `config.yml` & the `messages.yml` files from disk.
 
 ## Permissions
-ClansLite comes with 4 permissions:
+ClansLite comes with `8` permissions:
 * `clanslite.*`
 * `clanslite.clan`
 * `clanslite.admin`
 * `clanslite.update`
+* `clanslite.bypass`
+* `clanslite.bypass.*`
+* `clanslite.bypass.homecooldown`
+* `clanslite.bypass.pvp`
 
 `clanslite.*` is a permission to allow access to ALL functions regardless of operator status.
 `clanslite.clan` is by default given to everyone so they can all create, edit and manage a clan.  
 `clanslite.admin` is by default given to server operators.
 `clanslite.update` is the permission node to allow a player to see in game notifications if there is a plugin update available.
+`clanslite.bypass` is the permission node to allow a player to bypass all protections and cooldowns.
+`clanslite.bypass.*` is the permission node to allow a player to bypass all protections and cooldowns.
+`clanslite.bypass.homecooldown` is the permission node to allow a player to bypass the home command cooldown.
+`clanslite.bypass.pvp` is the permission node to allow a player to bypass the friendly fire protections.
 
 ## Config
 The max clan size (by default is 8), can be managed in the `plugins/ClansLite/config.yml` file.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ ClansLite exposes a variable of `{CLAN}` to use in Essentials Chat or similar.
 
 ## PlaceholderAPI
 ClansLite exposes `4` external placeholders using `PlaceholderAPI` to enable the fetching of a players clan name or the clan prefix or if the clan has friendly fire enabled or if the clan has a home set.
+
 The four available placeholders are:
 * `%clansLite_clanName%`
 * `%clansLite_clanPrefix%`

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>xyz.gamlin</groupId>
     <artifactId>ClansLite</artifactId>
-    <version>1.1.3</version>
+    <version>1.1.4</version>
     <packaging>jar</packaging>
 
     <name>ClansLite</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>xyz.gamlin</groupId>
     <artifactId>ClansLite</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
     <packaging>jar</packaging>
 
     <name>ClansLite</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>xyz.gamlin</groupId>
     <artifactId>ClansLite</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <packaging>jar</packaging>
 
     <name>ClansLite</name>

--- a/src/main/java/xyz/gamlin/clans/commands/ClanAdmin.java
+++ b/src/main/java/xyz/gamlin/clans/commands/ClanAdmin.java
@@ -36,7 +36,20 @@ public class ClanAdmin implements CommandExecutor {
                 }
                 if (args[0].equalsIgnoreCase("reload")) {
                     Clans.getPlugin().reloadConfig();
-                    Clans.getPlugin().clansFileManager.reloadClansConfig();
+                    try {
+                        ClansStorageUtil.saveClans();
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                        sender.sendMessage(ColorUtils.translateColorCodes(messagesConfig.getString("clans-save-error-1")));
+                        sender.sendMessage(ColorUtils.translateColorCodes(messagesConfig.getString("clans-save-error-2")));
+                    }
+                    try {
+                        ClansStorageUtil.restoreClans();
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                        sender.sendMessage(ColorUtils.translateColorCodes(messagesConfig.getString("clans-load-error-1")));
+                        sender.sendMessage(ColorUtils.translateColorCodes(messagesConfig.getString("clans-load-error-2")));
+                    }
                     Clans.getPlugin().messagesFileManager.reloadMessagesConfig();
                     sender.sendMessage(ColorUtils.translateColorCodes(messagesConfig.getString("plugin-reload-successful")));
                 }
@@ -65,7 +78,21 @@ public class ClanAdmin implements CommandExecutor {
                 }
                 if (args[0].equalsIgnoreCase("reload")) {
                     Clans.getPlugin().reloadConfig();
-                    Clans.getPlugin().clansFileManager.reloadClansConfig();
+                    try {
+                        ClansStorageUtil.saveClans();
+                    } catch (IOException e) {
+                        logger.severe(ColorUtils.translateColorCodes(messagesConfig.getString("clans-save-error-1")));
+                        logger.severe(ColorUtils.translateColorCodes(messagesConfig.getString("clans-save-error-2")));
+                        e.printStackTrace();
+                    }
+                    try {
+                        ClansStorageUtil.restoreClans();
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                        logger.severe(ColorUtils.translateColorCodes(messagesConfig.getString("clans-load-error-1")));
+                        logger.severe(ColorUtils.translateColorCodes(messagesConfig.getString("clans-load-error-2")));
+                        e.printStackTrace();
+                    }
                     Clans.getPlugin().messagesFileManager.reloadMessagesConfig();
                     logger.info(ColorUtils.translateColorCodes(messagesConfig.getString("plugin-reload-successful")));
                 }

--- a/src/main/java/xyz/gamlin/clans/commands/ClanCommand.java
+++ b/src/main/java/xyz/gamlin/clans/commands/ClanCommand.java
@@ -204,6 +204,7 @@ public class ClanCommand implements CommandExecutor {
                         Clan clan = ClansStorageUtil.findClanByOwner(ClanInviteUtil.getInviteOwner(inviterUUIDString.toString()));
                         if (clan != null) {
                             if (ClansStorageUtil.addClanMember(clan, player)) {
+                                ClanInviteUtil.removeInvite(player.getUniqueId().toString());
                                 String joinMessage = ColorUtils.translateColorCodes(messagesConfig.getString("clan-join-successful")).replace(CLAN_PLACEHOLDER, clan.getClanFinalName());
                                 player.sendMessage(joinMessage);
                             } else {
@@ -563,12 +564,19 @@ public class ClanCommand implements CommandExecutor {
                                 float pitch = clanByOwner.getClanHomePitch();
                                 if (clansConfig.getBoolean("clan-home.cool-down.enabled")){
                                     if (homeCoolDownTimer.containsKey(uuid)){
-                                        if (homeCoolDownTimer.get(uuid) > System.currentTimeMillis()){
-                                            Long timeLeft = (homeCoolDownTimer.get(uuid) - System.currentTimeMillis()) / 1000;
-                                            player.sendMessage(ColorUtils.translateColorCodes(messagesConfig.getString("cool-down-timer-wait")
-                                                    .replace(TIME_LEFT, timeLeft.toString())));
+                                        if (!(player.hasPermission("clanslite.bypass.homecooldown")||player.hasPermission("clanslite.bypass.*")
+                                                ||player.hasPermission("clanslite.bypass")||player.hasPermission("clanslite.*")||player.isOp())){
+                                            if (homeCoolDownTimer.get(uuid) > System.currentTimeMillis()){
+                                                Long timeLeft = (homeCoolDownTimer.get(uuid) - System.currentTimeMillis()) / 1000;
+                                                player.sendMessage(ColorUtils.translateColorCodes(messagesConfig.getString("cool-down-timer-wait")
+                                                        .replace(TIME_LEFT, timeLeft.toString())));
+                                            }else {
+                                                homeCoolDownTimer.put(uuid, System.currentTimeMillis() + (clansConfig.getLong("clan-home.cool-down.time") * 1000));
+                                                Location location = new Location(world, x, y, z, yaw, pitch);
+                                                player.teleport(location);
+                                                player.sendMessage(ColorUtils.translateColorCodes(messagesConfig.getString("successfully-teleported-to-home")));
+                                            }
                                         }else {
-                                            homeCoolDownTimer.put(uuid, System.currentTimeMillis() + (clansConfig.getLong("clan-home.cool-down.time") * 1000));
                                             Location location = new Location(world, x, y, z, yaw, pitch);
                                             player.teleport(location);
                                             player.sendMessage(ColorUtils.translateColorCodes(messagesConfig.getString("successfully-teleported-to-home")));
@@ -598,12 +606,19 @@ public class ClanCommand implements CommandExecutor {
                                 float pitch = clanByPlayer.getClanHomePitch();
                                 if (clansConfig.getBoolean("clan-home.cool-down.enabled")){
                                     if (homeCoolDownTimer.containsKey(uuid)){
-                                        if (homeCoolDownTimer.get(uuid) > System.currentTimeMillis()){
-                                            Long timeLeft = (homeCoolDownTimer.get(uuid) - System.currentTimeMillis()) / 1000;
-                                            player.sendMessage(ColorUtils.translateColorCodes(messagesConfig.getString("cool-down-timer-wait")
-                                                    .replace(TIME_LEFT, timeLeft.toString())));
+                                        if (!(player.hasPermission("clanslite.bypass.homecooldown")||player.hasPermission("clanslite.bypass.*")
+                                                ||player.hasPermission("clanslite.bypass")||player.hasPermission("clanslite.*")||player.isOp())){
+                                            if (homeCoolDownTimer.get(uuid) > System.currentTimeMillis()){
+                                                Long timeLeft = (homeCoolDownTimer.get(uuid) - System.currentTimeMillis()) / 1000;
+                                                player.sendMessage(ColorUtils.translateColorCodes(messagesConfig.getString("cool-down-timer-wait")
+                                                        .replace(TIME_LEFT, timeLeft.toString())));
+                                            }else {
+                                                homeCoolDownTimer.put(uuid, System.currentTimeMillis() + (clansConfig.getLong("clan-home.cool-down.time") * 1000));
+                                                Location location = new Location(world, x, y, z, yaw, pitch);
+                                                player.teleport(location);
+                                                player.sendMessage(ColorUtils.translateColorCodes(messagesConfig.getString("successfully-teleported-to-home")));
+                                            }
                                         }else {
-                                            homeCoolDownTimer.put(uuid, System.currentTimeMillis() + (clansConfig.getLong("clan-home.cool-down.time") * 1000));
                                             Location location = new Location(world, x, y, z, yaw, pitch);
                                             player.teleport(location);
                                             player.sendMessage(ColorUtils.translateColorCodes(messagesConfig.getString("successfully-teleported-to-home")));

--- a/src/main/java/xyz/gamlin/clans/expansions/PlayerClanExpansion.java
+++ b/src/main/java/xyz/gamlin/clans/expansions/PlayerClanExpansion.java
@@ -28,7 +28,7 @@ public class PlayerClanExpansion extends PlaceholderExpansion {
 
     @Override
     public @NotNull String getVersion() {
-        return "1.1.3";
+        return "1.1.4";
     }
 
     @Override

--- a/src/main/java/xyz/gamlin/clans/expansions/PlayerClanExpansion.java
+++ b/src/main/java/xyz/gamlin/clans/expansions/PlayerClanExpansion.java
@@ -28,7 +28,7 @@ public class PlayerClanExpansion extends PlaceholderExpansion {
 
     @Override
     public @NotNull String getVersion() {
-        return "1.1.1";
+        return "1.1.2";
     }
 
     @Override

--- a/src/main/java/xyz/gamlin/clans/expansions/PlayerClanExpansion.java
+++ b/src/main/java/xyz/gamlin/clans/expansions/PlayerClanExpansion.java
@@ -28,7 +28,7 @@ public class PlayerClanExpansion extends PlaceholderExpansion {
 
     @Override
     public @NotNull String getVersion() {
-        return "1.1.2";
+        return "1.1.3";
     }
 
     @Override

--- a/src/main/java/xyz/gamlin/clans/listeners/PlayerDamage.java
+++ b/src/main/java/xyz/gamlin/clans/listeners/PlayerDamage.java
@@ -34,6 +34,15 @@ public class PlayerDamage implements Listener {
                     if (attackingClanMembers.contains(hurtUUID) || attackingClan.getClanOwner().equals(hurtUUID)){
                         if (config.getBoolean("protections.pvp.pvp-command-enabled")){
                             if (!attackingClan.isFriendlyFireAllowed()){
+                                if (config.getBoolean("protections.pvp.enable-bypass-permission")){
+                                    if (attackingPlayer.hasPermission("clanslite.bypass.pvp")
+                                            ||attackingPlayer.hasPermission("clanslite.bypass.*")
+                                            ||attackingPlayer.hasPermission("clanslite.bypass")
+                                            ||attackingPlayer.hasPermission("clanslite.*")
+                                            ||attackingPlayer.isOp()){
+                                        return;
+                                    }
+                                }
                                 event.setCancelled(true);
                                 attackingPlayer.sendMessage(ColorUtils.translateColorCodes(messagesConfig.getString("friendly-fire-is-disabled")));
                             }
@@ -49,6 +58,15 @@ public class PlayerDamage implements Listener {
                         if (attackingMembers.contains(hurtUUID) || attackingClanByPlayer.getClanOwner().equals(hurtUUID)){
                             if (config.getBoolean("protections.pvp.pvp-command-enabled")){
                                 if (!attackingClanByPlayer.isFriendlyFireAllowed()){
+                                    if (config.getBoolean("protections.pvp.enable-bypass-permission")){
+                                        if (attackingPlayer.hasPermission("clanslite.bypass.pvp")
+                                                ||attackingPlayer.hasPermission("clanslite.bypass.*")
+                                                ||attackingPlayer.hasPermission("clanslite.bypass")
+                                                ||attackingPlayer.hasPermission("clanslite.*")
+                                                ||attackingPlayer.isOp()){
+                                            return;
+                                        }
+                                    }
                                     event.setCancelled(true);
                                     attackingPlayer.sendMessage(ColorUtils.translateColorCodes(messagesConfig.getString("friendly-fire-is-disabled")));
                                 }

--- a/src/main/java/xyz/gamlin/clans/utils/ClanInviteUtil.java
+++ b/src/main/java/xyz/gamlin/clans/utils/ClanInviteUtil.java
@@ -43,6 +43,13 @@ public class ClanInviteUtil {
         }
     }
 
+    public static void removeInvite(String inviteeUUID){
+        UUID uuid = UUID.fromString(inviteeUUID);
+        if (invitesList.containsKey(uuid)){
+            invitesList.remove(uuid);
+        }
+    }
+
     public static Set<Map.Entry<UUID, ClanInvite>> getInvites(){
         return invitesList.entrySet();
     }

--- a/src/main/java/xyz/gamlin/clans/utils/ClansStorageUtil.java
+++ b/src/main/java/xyz/gamlin/clans/utils/ClansStorageUtil.java
@@ -37,6 +37,7 @@ public class ClansStorageUtil {
     }
 
     public static void restoreClans() throws IOException {
+        clansList.clear();
         clansStorage.getConfigurationSection("clans.data").getKeys(false).forEach(key ->{
             UUID uuid = UUID.fromString(key);
             String clanFinalName = clansStorage.getString("clans.data." + key + ".clanFinalName");

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -18,6 +18,8 @@ protections:
   pvp:
     #Globally enable the clan friendly fire system. [Default value: true]
     pvp-command-enabled: true
+    #Enable the ability for a player to bypass the pvp protection using 'clanslite.bypass.pvp'. [Default value: true]
+    enable-bypass-permission: true
 
 #Clan home system
 clan-home:

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -117,6 +117,8 @@ auto-save-complete: "&6ClansLite: &aSaved all Clans to file!"
 auto-save-failed: "&6ClansLite: &4Failed to save clans.yml to file!"
 clans-save-error-1: "&6ClansLite: &4Failed to save clans.yml to file!"
 clans-save-error-2: "&6ClansLite: &4Check the console for errors!"
+clans-load-error-1: "&6ClansLite: &4Failed to load data from clans.yml!"
+clans-load-error-2: "&6ClansLite: &4See console for errors!"
 clans-update-error: "&6ClansLite: &4Failed to update clans.yml file!\n&6ClansLite: &4Check the console for errors!"
 
 #Update Notification

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -125,7 +125,7 @@ update-available:
   1: "&4*-------------------------------------------*"
   2: "&6ClansLite: &cA new version is available!"
   3: "&4*-------------------------------------------*"
-no-update-avaialbe:
+no-update-available:
   1: "&a*-------------------------------------------*"
   2: "&6ClansLite: &aPlugin is up to date!"
   3: "&a*-------------------------------------------*"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -10,19 +10,25 @@ softdepend: [PlaceholderAPI]
 commands:
   clan:
     description: Create, delete and manage clans!
-    usage: "Usage: /clan [created|disband|invite|kick|info|list|prefix|ally]"
+    usage: "Usage: /clan [created|disband|invite|kick|info|list|prefix|ally|sethome|home]"
     permission: clanslite.clan
     aliases:
       - clans
       - c
+      - cl
   clanadmin:
     description: Admin commands for clans
     usage: "Usage: /clanadmin [save|reload]"
     permission: clanslite.admin
     aliases:
       - ca
+      - cla
 permissions:
   clanslite.clan:
     default: true
   clanslite.clanadmin:
+    default: op
+  clanslite.update:
+    default: op
+  clanslite.bypass:
     default: op


### PR DESCRIPTION
Added new saveClans to ClanAdmin reload. Added new clearing of the clans hashmap when the data is restored to prevent duplication risk. Added new strings to messages.yml. Changed PlaceholderAPI Expansion version to `1.1.3`. Change plugin version to `1.1.3`. Users MUST regenerate their messages.yml file again.